### PR TITLE
Expose retransmits, fastRecoveries and rtoCount

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ class HyperswarmStats {
     this._packetsReceivedOverClosedSwarmStreams = 0
     this._retransmitsOfClosedSwarmStreams = 0
     this._fastRecoveriesOfClosedSwarmStreams = 0
+    this._rtoCountOfClosedSwarmStreams = 0
 
     swarm.on('connection', conn => {
       conn.on('close', () => {
@@ -79,6 +80,15 @@ class HyperswarmStats {
     }
 
     return countFromCurrentConns + this._fastRecoveriesOfClosedSwarmStreams
+  }
+
+  getRTOCountAcrossAllStreams () {
+    let countFromCurrentConns = 0
+    for (const conn of this.swarm.connections) {
+      countFromCurrentConns += conn.rawStream?.rtoCount || 0
+    }
+
+    return countFromCurrentConns + this._rtoCountOfClosedSwarmStreams
   }
 
   getBytesTransmittedAcrossAllStreams () {
@@ -401,6 +411,13 @@ class HyperswarmStats {
       help: 'Total UDX fast recoveries summed across the streams exposed explicitly by hyperswarm connections',
       collect () {
         this.set(self.getFastRecoveriesAcrossAllStreams())
+      }
+    })
+    new promClient.Gauge({ // eslint-disable-line no-new
+      name: 'hyperswarm_total_rto_count_over_swarm_streams',
+      help: 'Total UDX retransmission time-outs, summed across the streams exposed explicitly by hyperswarm connections',
+      collect () {
+        this.set(self.getRTOCountAcrossAllStreams())
       }
     })
   }

--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ class HyperswarmStats {
         this._packetsReceivedOverClosedSwarmStreams += conn.rawStream?.packetsReceived || 0
         this._retransmitsOfClosedSwarmStreams += conn.rawStream?.retransmits
         this._fastRecoveriesOfClosedSwarmStreams += conn.rawStream?.fastRecoveries
+        this._rtoCountOfClosedSwarmStreams += conn.rawStream?.rtoCount
       })
     })
   }

--- a/package.json
+++ b/package.json
@@ -30,5 +30,8 @@
     "hyperswarm": "^4.8.2",
     "prom-client": "^15.1.3",
     "standard": "^17.1.0"
+  },
+  "dependencies": {
+    "udx-native": "^1.12.0"
   }
 }

--- a/test.js
+++ b/test.js
@@ -5,7 +5,7 @@ const createTestnet = require('hyperdht/testnet')
 const b4a = require('b4a')
 const SwarmStats = require('.')
 
-const DEBUG = false
+const DEBUG = true
 
 test(async (t) => {
   const tPrep = t.test('prep')
@@ -123,6 +123,8 @@ test(async (t) => {
     t.is(getMetricValue(lines, 'hyperswarm_total_packets_received_over_swarm_streams') > 1, true, 'hyperswarm_total_packets_received_over_swarm_streams')
     t.is(getMetricValue(lines, 'hyperswarm_avg_congestion_window') > 1, true, 'hyperswarm_avg_congestion_window')
     t.is(getMetricValue(lines, 'hyperswarm_avg_mtu') > 1, true, 'hyperswarm_avg_mtu')
+    t.is(getMetricValue(lines, 'hyperswarm_total_retransmits_over_swarm_streams'), 0, 'hyperswarm_total_retransmits_over_swarm_streams')
+    t.is(getMetricValue(lines, 'hyperswarm_total_fast_recoveries_over_swarm_streams') > 1, true, 'hyperswarm_total_fast_recoveries_over_swarm_streams')
   }
 
   await swarm2.destroy()

--- a/test.js
+++ b/test.js
@@ -5,7 +5,7 @@ const createTestnet = require('hyperdht/testnet')
 const b4a = require('b4a')
 const SwarmStats = require('.')
 
-const DEBUG = true
+const DEBUG = false
 
 test(async (t) => {
   const tPrep = t.test('prep')
@@ -124,7 +124,8 @@ test(async (t) => {
     t.is(getMetricValue(lines, 'hyperswarm_avg_congestion_window') > 1, true, 'hyperswarm_avg_congestion_window')
     t.is(getMetricValue(lines, 'hyperswarm_avg_mtu') > 1, true, 'hyperswarm_avg_mtu')
     t.is(getMetricValue(lines, 'hyperswarm_total_retransmits_over_swarm_streams'), 0, 'hyperswarm_total_retransmits_over_swarm_streams')
-    t.is(getMetricValue(lines, 'hyperswarm_total_fast_recoveries_over_swarm_streams') > 1, true, 'hyperswarm_total_fast_recoveries_over_swarm_streams')
+    t.is(getMetricValue(lines, 'hyperswarm_total_fast_recoveries_over_swarm_streams'), 0, 'hyperswarm_total_fast_recoveries_over_swarm_streams')
+    t.is(getMetricValue(lines, 'hyperswarm_total_rto_count_over_swarm_streams'), 0, 'hyperswarm_total_rto_count_over_swarm_streams')
   }
 
   await swarm2.destroy()


### PR DESCRIPTION
Temporarily adding udx dep, since we need 1.12.0 to access those stats (latest is set at 1.11.2, since 1.12.0 contains a bug)